### PR TITLE
feat: add state to browser interface

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,16 @@
+name: Tests
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - '.gitignore'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run Jest
+      uses: stefanoeb/jest-action@1.0.3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Install modules
-      run: npm install
-    - name: Run Jest
-      uses: stefanoeb/jest-action@1.0.3
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.13.1
+    - run: npm ci
+    - run: npm test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,5 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Install modules
+      run: npm install
     - name: Run Jest
       uses: stefanoeb/jest-action@1.0.3

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ declare global {
   interface Window {
     FEATURES: Record<
       string,
-      { enable: () => void; disable: () => void }
+      { enable: () => void; disable: () => void, state: () => boolean }
     >;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,46 @@
 /// <reference types="next" />
 import * as Next from "next";
-import getConfig from 'next/config';
+import getConfig from "next/config";
 
 export const isServer = () => {
-  return typeof window === 'undefined';
+  return typeof window === "undefined";
 };
 
 const _parseCookie = (cookie: string) => {
   // FEATURE_HIDE_PLP=true;FEATURE_NO_LOGIN=false;
   return cookie
-    .split(';')
+    .split(";")
     .map((cookieKeyVal) => {
-      const [key, val] = cookieKeyVal.split('=');
-
+      const [key, val] = cookieKeyVal.split("=");
       return { [key.trim()]: decodeURI(val).trim() };
     })
     .reduce((cookieParsed, keyValPair) => ({ ...cookieParsed, ...keyValPair }));
 };
 
 const _stringToBool = (boolString: string) => {
-  if (boolString.toLowerCase() === 'true' || boolString === '1') {
+  if (boolString.toLowerCase() === "true" || boolString === "1") {
     return true;
+  }
+
+  return false;
+};
+
+const getFeatureFromCookie = (
+  cookieName: string,
+  {
+    context,
+    htmlDocument,
+  }: {
+    context?: Next.GetServerSidePropsContext;
+    htmlDocument: { cookie: any };
+  }
+) => {
+  const fromCookie = isServer()
+    ? context?.req.cookies[cookieName]
+    : _parseCookie(htmlDocument.cookie)[cookieName];
+
+  if (fromCookie) {
+    return _stringToBool(fromCookie);
   }
 
   return false;
@@ -30,17 +50,22 @@ export const configure = <KeysType extends string>(
   {
     featureFlags,
     allowCookieOverride,
+    debug,
   }: {
     featureFlags: KeysType[];
     allowCookieOverride: KeysType[];
-  } = { featureFlags: [], allowCookieOverride: [] },
+    debug?: boolean;
+  } = { featureFlags: [], allowCookieOverride: [] }
 ) => {
   defineWindowInterface(featureFlags, allowCookieOverride);
 
   const { serverRuntimeConfig, publicRuntimeConfig } = getConfig();
 
   return {
-    getFeatureFlag: (key: KeysType, context?: Next.GetServerSidePropsContext) => {
+    getFeatureFlag: (
+      key: KeysType,
+      context?: Next.GetServerSidePropsContext
+    ) => {
       const index = `FEATURE_${key}`;
 
       if (allowCookieOverride.includes(key)) {
@@ -58,7 +83,11 @@ export const configure = <KeysType extends string>(
         return _stringToBool(fromEnv);
       }
 
-      console.warn(`Feature flag "${key}" does not exist on next-feature-flags`);
+      debug
+        ? console.warn(
+            `Feature flag "${key}" does not exist on next-feature-flags`
+          )
+        : null;
       return false;
     },
   };
@@ -67,22 +96,25 @@ export const configure = <KeysType extends string>(
 // Sets an interface on window to enable and disable feature flags
 function defineWindowInterface(
   featureFlags: string[],
-  allowCookieOverride: string[],
+  allowCookieOverride: string[]
 ) {
   if (!isServer()) {
     window.FEATURES =
       window.FEATURES ||
-        featureFlags.reduce((features, key) => {
+      featureFlags.reduce((features, key) => {
         // Only create interface for features with override
         if (!allowCookieOverride.includes(key)) {
           return features;
+
         }
 
+        const cookieName = `FEATURE_${key}`;
         return {
           ...features,
           [key]: {
-            enable: () => (document.cookie = `FEATURE_${key}=true`),
-            disable: () => (document.cookie = `FEATURE_${key}=false`),
+            enable: () => (document.cookie = `${cookieName}=true;`),
+            disable: () => (document.cookie = `${cookieName}=false;`),
+            state: () => getFeatureFromCookie(cookieName, { htmlDocument: document }),
           },
         };
       }, {});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "outDir": "build/compiled",
     "declaration": true,
     "target": "es2017",
+    "typeRoots": ["./node_modules/@types", "./index.d.ts"]
   },
-  "include": ["src", "index.ts", "index.d.ts"],
+  "include": ["src", "src/index.ts", "index.d.ts"],
   "exclude": ["node_modules", "compiled", "**/*.spec.ts"]
 }


### PR DESCRIPTION
- Adds API to get state of a feature flag from cookie while on browser via `window.FEATURE_ABCD.state()`
- Adds (or tries to) add github actions to run tests on PRs