### PR TITLE
fix(window.FEATURES.feature): state function reads from environment when cookie not available

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -383,6 +383,21 @@ describe("window interface", () => {
     expect(window.FEATURES.FOO.state()).toEqual('true');
   });
 
+  it("shows state of the feature from env when cookie not available", () => {
+    utilMockGetConfigForEnvVariable({
+      FEATURE_BAR: "false",
+      FEATURE_FOO: "true"
+    });
+
+    configure({
+      featureFlags: ["FOO", "BAR"],
+      allowCookieOverride: ["FOO", "BAR"],
+    });
+
+    expect(window.FEATURES.BAR.state()).toEqual('false');
+    expect(window.FEATURES.FOO.state()).toEqual('true');
+  });
+
   it("only provide interface to overridable variables", () => {
     document.cookie = "FEATURE_FOO=true";
     document.cookie = "FEATURE_BAR=false";

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -398,6 +398,16 @@ describe("window interface", () => {
     expect(window.FEATURES.FOO.state()).toEqual('true');
   });
 
+  it("shows state false when feature not available", () => {
+    configure({
+      featureFlags: ["FOO", "BAR"],
+      allowCookieOverride: ["FOO", "BAR"],
+    });
+
+    expect(window.FEATURES.BAR.state()).toEqual('false');
+    expect(window.FEATURES.FOO.state()).toEqual('false');
+  });
+
   it("only provide interface to overridable variables", () => {
     document.cookie = "FEATURE_FOO=true";
     document.cookie = "FEATURE_BAR=false";

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -379,8 +379,8 @@ describe("window interface", () => {
       allowCookieOverride: ["FOO", "BAR"],
     });
 
-    expect(window.FEATURES.BAR.state()).toBeFalsy();
-    expect(window.FEATURES.FOO.state()).toBeTruthy();
+    expect(window.FEATURES.BAR.state()).toEqual('false');
+    expect(window.FEATURES.FOO.state()).toEqual('true');
   });
 
   it("only provide interface to overridable variables", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,13 +107,14 @@ function defineWindowInterface(
           return features;
         }
 
-        const cookieName = `FEATURE_${key}`;
+        const featureKey = `FEATURE_${key}`;
         return {
           ...features,
           [key]: {
-            enable: () => (document.cookie = `${cookieName}=true;`),
-            disable: () => (document.cookie = `${cookieName}=false;`),
-            state: () => getFeatureFromCookie(cookieName, { htmlDocument: document })
+            enable: () => (document.cookie = `${featureKey}=true;`),
+            disable: () => (document.cookie = `${featureKey}=false;`),
+            state: () =>
+              getFeatureFromCookie(featureKey, { htmlDocument: document }) || getFeatureFromEnv(featureKey)
           },
         };
       }, {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,14 @@ const getFeatureFromCookie = (
 const getFeatureFromEnv = (key: string) => {
   const { serverRuntimeConfig, publicRuntimeConfig } = getConfig() || {};
 
+  /*
+   * Question: should this instead be:
+   *
+   * serverRuntimeConfig[key] ?? publicRuntimeConfig[key]
+   *
+   * Returns publicRuntimeConfig[key] if serverRuntimeConfig[key] is null or undefined
+   * Returns serverRuntimeConfig[key] if is 0 or ""
+   */
   return serverRuntimeConfig[key] || publicRuntimeConfig[key];
 }
 
@@ -50,7 +58,6 @@ export const configure = <KeysType extends string>(
   } = { featureFlags: [], allowCookieOverride: [] }
 ) => {
   defineWindowInterface(featureFlags, allowCookieOverride);
-
 
   return {
     getFeatureFlag: (

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,14 +107,16 @@ function defineWindowInterface(
           return features;
         }
 
-        const featureKey = `FEATURE_${key}`;
+        const cookieName = `FEATURE_${key}`;
         return {
           ...features,
           [key]: {
-            enable: () => (document.cookie = `${featureKey}=true;`),
-            disable: () => (document.cookie = `${featureKey}=false;`),
+            enable: () => (document.cookie = `${cookieName}=true;`),
+            disable: () => (document.cookie = `${cookieName}=false;`),
             state: () =>
-              getFeatureFromCookie(featureKey, { htmlDocument: document }) || getFeatureFromEnv(featureKey)
+              getFeatureFromCookie(cookieName, { htmlDocument: document })
+              || getFeatureFromEnv(cookieName)
+              || 'false'
           },
         };
       }, {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ const getFeatureFromCookie = (
 const getFeatureFromEnv = (key: string) => {
   const { serverRuntimeConfig, publicRuntimeConfig } = getConfig() || {};
 
-  return serverRuntimeConfig[key] || publicRuntimeConfig[key];
+  return serverRuntimeConfig[key] ?? publicRuntimeConfig[key];
 }
 
 export const configure = <KeysType extends string>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,14 +35,6 @@ const getFeatureFromCookie = (
 const getFeatureFromEnv = (key: string) => {
   const { serverRuntimeConfig, publicRuntimeConfig } = getConfig() || {};
 
-  /*
-   * Question: should this instead be:
-   *
-   * serverRuntimeConfig[key] ?? publicRuntimeConfig[key]
-   *
-   * Returns publicRuntimeConfig[key] if serverRuntimeConfig[key] is null or undefined
-   * Returns serverRuntimeConfig[key] if is 0 or ""
-   */
   return serverRuntimeConfig[key] || publicRuntimeConfig[key];
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "target": "es2017"
   },
   "include": ["src", "index.ts", "index.d.ts"],
-  "exclude": ["node_modules", "compiled", "**/*.spec.ts"]
+  "exclude": ["node_modules", "compiled"]
 }


### PR DESCRIPTION
Changelist:

- One line `_stringToBool`
- Add `getFeatureFromEnv`
  - Ensure `getFeatureFromEnv` and `getFeatureFromCookie` have similar return types
- Add spec 
  - "shows state of the feature from env when cookie not available"
  - "shows state false when feature not available"
- Change spec
  - "shows state of the feature from cookie"
    - Compare against defined values instead of `truthy` and `falsey` 
 - Refactor variable names to be similar across functions 